### PR TITLE
fix(schema): Include Dataset in the Experiment schema

### DIFF
--- a/api/crud.py
+++ b/api/crud.py
@@ -23,8 +23,8 @@ def get_datasets(db: Session) -> list[models.Dataset]:
     return db.query(models.Dataset).all()
 
 
-def get_dataset(db: Session, name: str) -> models.Dataset | None:
-    return db.query(models.Dataset).filter(models.Dataset.name == name).first()
+def get_dataset(db: Session, dataset_id: str) -> models.Dataset | None:
+    return db.query(models.Dataset).filter(models.Dataset.name == dataset_id).first()
 
 
 def get_model(db: Session, model_id: int) -> models.Model | None:

--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -36,9 +36,9 @@ def read_datasets(db: Session = Depends(get_db)):
     return crud.get_datasets(db)
 
 
-@router.get("/dataset/{name}", response_model=schemas.Dataset | schemas.DatasetFull)
-def read_dataset(name: str, with_df: bool = False, db: Session = Depends(get_db)):
-    dataset = crud.get_dataset(db, name)
+@router.get("/dataset/{id}", response_model=schemas.Dataset | schemas.DatasetFull)
+def read_dataset(id: int, with_df: bool = False, db: Session = Depends(get_db)):
+    dataset = crud.get_dataset(db, id)
     if dataset is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -271,8 +271,8 @@ class Experiment(ExperimentBase):
     num_try: int
     num_success: int
 
+    dataset: Dataset
     model: Model | None
-    dataset_id: int
 
 
 class ExperimentWithResults(Experiment):


### PR DESCRIPTION
- Use dataset_id instead of dataset_name for GET /dataset.
- Add Dataset to the experiment schema instead of the dataset_id .

Exemple of the modification impact @AudreyCLEVY : 
 
before : 
`response = requests.get(f'{API_URL}/v1/dataset/{experiment["dataset_id"]}?with_df=True')`

after : 
`response = requests.get(f'{API_URL}/v1/dataset/{experiment["dataset"]["id"]}?with_df=True')`

