### PR TITLE
feat: support for delete expe route for admin user

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -13,7 +13,7 @@ dotenv.load_dotenv()
 ### App metadata
 #######################################################################
 
-APP_NAME = "eg1" # redundant wuth pyproject.name
+APP_NAME = "eg1"  # redundant wuth pyproject.name
 APP_DESCRIPTION = "Albert Evaluations API"
 CONTACT = {
     "name": "Etalab - Datalab",
@@ -45,6 +45,12 @@ DEFAULT_JUDGE_MODEL = "gpt-4o-mini"
 MFS_API_KEY_V2 = os.getenv("MFS_API_KEY_V2")
 
 #######################################################################
+### Auth
+#######################################################################
+ADMIN_TOKENS = [os.getenv("ADMIN_TOKEN")] if os.getenv("ADMIN_TOKEN") else []
+
+
+#######################################################################
 ### Environment specific
 #######################################################################
 
@@ -55,7 +61,9 @@ if ENV == "unittest":
 elif ENV == "dev":
     API_BASE_URL = "http://localhost:8000" + API_PREFIX
     DB_NAME = "eg1_dev"
-    DATABASE_URL = os.getenv("POSTGRES_URL", "postgresql+psycopg2://postgres:changeme@localhost:5432")
+    DATABASE_URL = os.getenv(
+        "POSTGRES_URL", "postgresql+psycopg2://postgres:changeme@localhost:5432"
+    )
     DATABASE_URI = DATABASE_URL.rstrip("/") + "/" + DB_NAME
 else:
     API_BASE_URL = "http://localhost:8000" + API_PREFIX

--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -9,6 +9,7 @@ from api.db import get_db
 from api.errors import CustomIntegrityError, SchemaError
 from api.metrics import Metric, metric_registry
 from api.runners import dispatch_tasks
+from api.security import admin_only
 
 router = APIRouter()
 
@@ -128,11 +129,11 @@ def patch_experiment(
     return experiment
 
 
-@router.delete("/experiment/{id}", status_code=204)
+@router.delete("/experiment/{id}")
 def delete_experiment(id: int, db: Session = Depends(get_db)):
     if not crud.remove_experiment(db, id):
         raise HTTPException(status_code=404, detail="Experiment not found")
-    return
+    return "ok"
 
 
 @router.get(
@@ -239,8 +240,8 @@ def read_experimentset(id: int, db: Session = Depends(get_db)):
     return experimentset
 
 
-@router.delete("/experiment_set/{id}", status_code=204)
-def delete_experimentset(id: int, db: Session = Depends(get_db)):
+@router.delete("/experiment_set/{id}")
+def delete_experimentset(id: int, db: Session = Depends(get_db), admin_check=Depends(admin_only)):
     if not crud.remove_experimentset(db, id):
         raise HTTPException(status_code=404, detail="ExperimentSet not found")
-    return
+    return "ok"

--- a/api/models.py
+++ b/api/models.py
@@ -107,7 +107,7 @@ class Result(Base):
     experiment_id = Column(Integer, ForeignKey("experiments.id"))
     experiment = relationship("Experiment", back_populates="results")
     # Many
-    observation_table = relationship("ObservationTable", back_populates="result")
+    observation_table = relationship("ObservationTable", back_populates="result", cascade="all, delete-orphan")
 
 
 class ObservationTable(Base):
@@ -159,7 +159,7 @@ class Experiment(Base):
     dataset_id = Column(Integer, ForeignKey("datasets.id"))
     dataset = relationship("Dataset")
     model_id = Column(Integer, ForeignKey("models.id"))
-    model = relationship("Model")
+    model = relationship("Model", cascade="all, delete-orphan", single_parent=True)
     experiment_set_id = Column(Integer, ForeignKey("experiment_sets.id"))
     experiment_set = relationship("ExperimentSet", back_populates="experiments")
     # Many

--- a/api/security.py
+++ b/api/security.py
@@ -1,0 +1,8 @@
+from fastapi import Header, HTTPException
+
+from api.config import ADMIN_TOKENS
+
+
+async def admin_only(x_eg1_admin: str = Header(default=None)):
+    if ADMIN_TOKENS and x_eg1_admin not in ADMIN_TOKENS:
+        raise HTTPException(status_code=401, detail="Unauthorized: Please contact an admin to perform this request.")


### PR DESCRIPTION
In this MR:

- support for DELETE /experiment and DELETE /experiment_set route (with cascade !)
- add a security "admin" user to protect those route to avoid user to remove other experiment (because there no user management yet on eg1)

@AudreyCLEVY  (I will stop tagging you on every PR from now, but note that you can configure what actions should notify you automatically in the "watching" options of github ;)