### PR TITLE
fixfeat: expset view and force retry

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -38,7 +38,7 @@ BACKEND_CORS_ORIGINS = ["*"]
 API_PREFIX = ""
 
 # Runners
-MAX_CONCURRENT_TASKS = 12  # 8 ok, 16 hard !
+MAX_CONCURRENT_TASKS = 8  # 8 ok, 16 hard !
 DEFAULT_JUDGE_MODEL = "gpt-4o-mini"
 
 # Soon obsolete

--- a/ui/demo_streamlit/views/datasets.py
+++ b/ui/demo_streamlit/views/datasets.py
@@ -13,7 +13,7 @@ def main():
     datasets = fetch("get", "/datasets")
     if not datasets:
         return
-    
+
     # Main content
     main_content, right_menu = st.columns([8, 2])
 

--- a/ui/demo_streamlit/views/experiments.py
+++ b/ui/demo_streamlit/views/experiments.py
@@ -10,26 +10,32 @@ from io import StringIO
 FINISHED_STATUS = "finished"
 UNKNOWN_MODEL = "Unknown Model"
 
-@st.cache_data
-def fetch_all_experiments() -> list[dict]:
-    return fetch("get", "/experiments")
 
-@st.cache_data
+def fetch_all_experiments() -> list[dict]:
+    return fetch("get", "/experiments", {"orphan": True, "backward": True})
+
+
 def fetch_experiment_results(exp_id: int) -> dict:
     return fetch("get", f"/experiment/{exp_id}", {"with_dataset": "true"})
+
 
 def process_experiment_results(experiment: dict) -> pd.DataFrame | None:
     df = pd.read_json(StringIO(experiment["dataset"]["df"]))
 
     if "answers" in experiment:
-        df["answer"] = df.index.map({answer["num_line"]: answer["answer"] for answer in experiment["answers"]})
+        df["answer"] = df.index.map(
+            {answer["num_line"]: answer["answer"] for answer in experiment["answers"]}
+        )
 
     if "results" in experiment:
         for result in experiment["results"]:
             metric_name = result["metric_name"]
-            df[f"result_{metric_name}"] = df.index.map({obs["num_line"]: obs["score"] for obs in result["observation_table"]})
+            df[f"result_{metric_name}"] = df.index.map(
+                {obs["num_line"]: obs["score"] for obs in result["observation_table"]}
+            )
 
     return df
+
 
 def calculate_metric_stats(arr: np.array) -> dict[str, float]:
     return {
@@ -37,21 +43,35 @@ def calculate_metric_stats(arr: np.array) -> dict[str, float]:
         "std": np.std(arr),
         "median": np.median(arr),
         "mean_std": f"{arr.mean():.2f} ± {arr.std():.2f}",
-        "support": len(arr)
+        "support": len(arr),
     }
+
 
 def process_experiment_aggregated_results(experiment: dict) -> pd.DataFrame:
     df_metrics = {
-        metric_results["metric_name"]: pd.DataFrame([calculate_metric_stats(np.array([x["score"] for x in metric_results["observation_table"] if pd.notna(x["score"])]))])
+        metric_results["metric_name"]: pd.DataFrame(
+            [
+                calculate_metric_stats(
+                    np.array(
+                        [
+                            x["score"]
+                            for x in metric_results["observation_table"]
+                            if pd.notna(x["score"])
+                        ]
+                    )
+                )
+            ]
+        )
         for metric_results in experiment.get("results", [])
-        if len([x["score"] for x in metric_results["observation_table"] if pd.notna(x["score"])]) > 0
+        if len([x["score"] for x in metric_results["observation_table"] if pd.notna(x["score"])])
+        > 0
     }
     return pd.DataFrame(
         {metric_name: df["mean_std"].iloc[0] for metric_name, df in sorted(df_metrics.items())},
-        index=[experiment["name"]]
+        index=[experiment["name"]],
     )
 
-@st.cache_data
+
 def preprocess_experiments(experiments: list[dict]) -> pd.DataFrame:
     formatted_experiments = [
         {
@@ -59,13 +79,17 @@ def preprocess_experiments(experiments: list[dict]) -> pd.DataFrame:
             "name": exp["name"],
             "dataset": exp["dataset"]["name"],
             "model": exp["model"]["name"] if exp["model"] else "N/A",
-            **{f"{result['metric_name']}_score": f"{sum(obs['score'] for obs in result['observation_table'] if obs['score'] is not None) / len([obs for obs in result['observation_table'] if obs['score'] is not None]):.2f}"
-               for result in exp.get("results", []) if any(obs['score'] is not None for obs in result['observation_table'])}
+            **{
+                f"{result['metric_name']}_score": f"{sum(obs['score'] for obs in result['observation_table'] if obs['score'] is not None) / len([obs for obs in result['observation_table'] if obs['score'] is not None]):.2f}"
+                for result in exp.get("results", [])
+                if any(obs["score"] is not None for obs in result["observation_table"])
+            },
         }
         for exp in experiments
-        if exp["experiment_status"] == FINISHED_STATUS and exp["experiment_set_id"] is None
+        if exp["experiment_status"] == FINISHED_STATUS
     ]
     return pd.DataFrame(formatted_experiments)
+
 
 def display_experiment_results(exp_id: int):
     experiment = fetch_experiment_results(exp_id)
@@ -81,7 +105,7 @@ def display_experiment_results(exp_id: int):
         st.warning("Warning: some metrics have failed.")
 
     dataset_name = experiment["dataset"]["name"]
-    model_name =  experiment.get("model") or UNKNOWN_MODEL
+    model_name = experiment.get("model") or UNKNOWN_MODEL
     aggregated_df = process_experiment_aggregated_results(experiment)
     results_df = process_experiment_results(experiment)
 
@@ -98,6 +122,7 @@ def display_experiment_results(exp_id: int):
     else:
         st.info("No results available for this experiment.")
 
+
 def main():
     st.title("Experiments (not in a Set)")
     st.info("Here, you can see the experiments that are not in evaluation sets.")
@@ -113,7 +138,12 @@ def main():
         metric_columns = [col for col in df.columns if col.endswith("_score")]
         df = df[df[metric_columns].notna().any(axis=1)]
 
-        st.dataframe(df)
+        st.dataframe(
+            df,
+            use_container_width=True,
+            hide_index=True,
+            column_config={"id": st.column_config.TextColumn(width="small")},
+        )
 
         st.divider()
 
@@ -123,12 +153,12 @@ def main():
             label="",
             options=df["id"].tolist(),
             format_func=lambda x: f"Experiment {x}",
-            label_visibility="collapsed"
+            label_visibility="collapsed",
         )
         if st.button("Show Selected Experiment Results"):
             display_experiment_results(selected_exp_id)
     else:
         st.info("No finished experiments found.")
 
-main()
 
+main()

--- a/ui/demo_streamlit/views/leaderboard.py
+++ b/ui/demo_streamlit/views/leaderboard.py
@@ -99,36 +99,36 @@ def main():
     tabs = st.tabs(list(grouped_datasets.keys()))
 
     for group_index, (group_label, datasets_in_group) in enumerate(grouped_datasets.items()):
-        with tabs[group_index]: 
+        with tabs[group_index]:
             leaderboard_data = fetch_leaderboard(DEFAULT_METRIC)
-            
+
             group_entries = [
                 entry for entry in leaderboard_data.get("entries", [])
-                if entry["dataset_name"].startswith(group_label) 
+                if entry["dataset_name"].startswith(group_label)
             ]
-            
+
             if group_entries:
                 metric_name, dataset_name, current_page_input, rows_per_page = create_ui_elements(group_label.split()[0], available_metrics, datasets_in_group, group_index)
-                
+
                 dataset_filter = None if dataset_name == "All" else dataset_name
-                
+
                 if metric_name != DEFAULT_METRIC or dataset_filter:
                     leaderboard_data = fetch_leaderboard(metric_name, dataset_filter)
-                
+
                 st.write(f"## 🏆 Top Performing LLMs - {metric_name.replace('_', ' ').title()}")
                 if dataset_filter:
                     st.write(f"Dataset: {dataset_filter}")
-                
+
                 df = process_leaderboard_data(leaderboard_data, group_label.split()[0], metric_name)
 
                 if df is not None and not df.empty:
                     total_entries = len(df)
-                    num_pages = (total_entries - 1) // rows_per_page + 1  
-                    current_page = min(current_page_input, num_pages)  
+                    num_pages = (total_entries - 1) // rows_per_page + 1
+                    current_page = min(current_page_input, num_pages)
                     st.session_state[f'page_{group_label.split()[0]}'] = current_page
-                    
-                    start_idx = (current_page - 1) * rows_per_page  
-                    end_idx = start_idx + rows_per_page  
+
+                    start_idx = (current_page - 1) * rows_per_page
+                    end_idx = start_idx + rows_per_page
 
                     st.dataframe(
                         df.iloc[start_idx:end_idx],


### PR DESCRIPTION
In this Merge Request (MR):

- **Enhancements to Experiment Set (expset) View:**
  - The expset view can now be shared via URL, making it easier to share specific results and scores.
  - Partially finished experiments are now viewable, allowing for progress tracking.
  - The header in the expset view has been improved to display success and failure rates.
  - The README is now included in the experiment details.
  - The score table has been enhanced to include mean and standard deviation for each score/metric.
  - Scores are now set as the default view.

- **Automatic Aggregation:**
  - Added auto-aggregation of model repetitions in the score table (for repeated experiment sets).

- **Bug Fixes:**
  - Resolved the orphan experiment filter issue.
  - Fixed the bug related to Streamlit caching.

- **New Parameters:**
  - Added a 'force' parameter to the /retry/experiment_set endpoint to allow for the rerun of unfinished experiments.
