### PR TITLE
fix: hide dummy dataset + add delete route for dataset

### DIFF
--- a/api/crud.py
+++ b/api/crud.py
@@ -1,8 +1,9 @@
+from sqlalchemy import and_, desc, func
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import func, desc, and_
 
 import api.models as models
 import api.schemas as schemas
+from api.errors import CustomIntegrityError, SchemaError
 from api.metrics import Metric, metric_registry
 from api.models import create_object_from_dict
 
@@ -47,6 +48,28 @@ def update_dataset(
     db.commit()
     db.refresh(db_dataset)
     return db_dataset
+
+
+def remove_dataset(db: Session, dataset_id: int) -> bool:
+    linked_experiments = (
+        db.query(func.count(models.Experiment.id))
+        .filter(models.Experiment.dataset_id == dataset_id)
+        .scalar()
+    )
+    if linked_experiments > 0:
+        raise SchemaError(
+            f"This dataset is linked to {linked_experiments} experiments.\n"
+            "You must either delete linked experiments or associated them to another dataset to remove this one."
+        )
+
+    db_dataset = db.query(models.Dataset).get(dataset_id)
+    if db_dataset is None:
+        return False
+
+    db.delete(db_dataset)
+    db.commit()
+    # update_db_exp(db, dataset_id, dict(is_archived=True))
+    return True
 
 
 #

--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -69,6 +69,23 @@ def patch_dataset(id: int, dataset_patch: schemas.DatasetPatch, db: Session = De
     return db_dataset
 
 
+@router.delete(
+    "/dataset/{id}",
+    tags=["datasets"],
+)
+def delete_dataset(id: int, db: Session = Depends(get_db), admin_check=Depends(admin_only)):
+    try:
+        if not crud.remove_dataset(db, id):
+            raise HTTPException(status_code=404, detail="Dataset not found")
+        return "ok"
+    except (SchemaError, ValidationError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except IntegrityError as e:
+        return CustomIntegrityError.from_integrity_error(e.orig).to_http_response()
+    except Exception as e:
+        raise e
+
+
 #
 # Metrics
 #

--- a/ui/demo_streamlit/views/datasets.py
+++ b/ui/demo_streamlit/views/datasets.py
@@ -23,6 +23,10 @@ def main():
                      """)
 
         for dataset in datasets:
+            if "output" in dataset["columns"]:
+                # @DEBUG: dataset to be removed soon
+                continue
+
             when = datetime.fromisoformat(dataset["created_at"]).strftime("%d %B %Y")
             with st.container():
                 st.markdown(
@@ -31,12 +35,12 @@ def main():
                 )
                 st.subheader(dataset["name"])
                 st.write(
-                    f"Columns: {', '.join(map(lambda x: '**' + x + '**', dataset["columns"]))}"
+                    f"Columns: {', '.join(map(lambda x: '**' + x + '**', dataset['columns']))}"
                 )
                 st.markdown(dataset.get("readme", "No description available"))
                 col1, col2, col3, col4 = st.columns([1 / 8, 2 / 8, 2 / 8, 3 / 8])
                 with col1:
-                    st.caption(f'Id: {dataset["id"]} ')
+                    st.caption(f"Id: {dataset['id']} ")
                 with col2:
                     st.caption(f"Rows: {dataset['size']}")
                 with col3:
@@ -53,7 +57,7 @@ def main():
                 f"""
                 <a href="#{dataset_id}" style="color:grey;"
                    onclick="document.getElementById('{dataset_id}').scrollIntoView({{behavior: 'smooth'}});">
-                    {dataset['name']}
+                    {dataset["name"]}
                 </a><br>
             """,
                 unsafe_allow_html=True,


### PR DESCRIPTION
Cette MR propose une solution temporaire, mais rapide et simple pour retirer les "dummy" dataset du front. 

La route api pour delete les dataset est ajouté avec une sécurité. Pour delete complètement un dataset il faut d'abord linker tout les expérience qui utilise ce dataset vers un autre....


@AudreyCLEVY @camilleAND 