### PR TITLE
feat(ui): sort experiments set score table and highlight min/max metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ python_functions = ["test_*"]
 # Linter
 
 [tool.ruff]
-line-length = 100
+line-length = 111
 exclude = ["alembic/versions/"]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
In this PR : 

- sort experiment scores table (fix the sorting with string format {mean}  ± {std}, 
- highlight min/max value in each columns

