### PR TITLE
Support output_true columns in datasets that can be casted as an integer.

### DIFF
--- a/eg1/runners/dispatcher.py
+++ b/eg1/runners/dispatcher.py
@@ -154,7 +154,7 @@ def dispatch_tasks(db, db_exp, message_type: MessageType):
                         "line_id": num_line,
                         "metric_name": result.metric_name,
                         "output": a.answer,
-                        "output_true": row.get("output_true"),
+                        "output_true": str(row.get("output_true")),
                     }
                 )
 
@@ -261,7 +261,7 @@ def dispatch_retries(db, retry_runs: schemas.RetryRuns):
                     "line_id": obs.num_line,
                     "metric_name": result.metric_name,
                     "output": output,
-                    "output_true": row.get("output_true"),
+                    "output_true": str(row.get("output_true")),
                 }
             )
             num_line_added + [answer.num_line]
@@ -296,7 +296,7 @@ def dispatch_retries(db, retry_runs: schemas.RetryRuns):
                     "line_id": num_line,
                     "metric_name": result.metric_name,
                     "output": output,
-                    "output_true": row.get("output_true"),
+                    "output_true": str(row.get("output_true")),
                 }
             )
 


### PR DESCRIPTION
Hi, i'have played with eg1 and this is great.
I've encountered a little issue

In a dataset, if the column is casted as an integer (this will happen if the column ony has numbers), the JSON serialization fails.

One can replicate with dataset

```csv
title, query, output_true
"test", "ma query", "12"
```
and metric `output_length_score`

Casting the output as a string will make the JSON serialization succeed.

Note : This fix works for my case, i'm not 100% sure this is the best way to implement it.


Thanks for your work !