### PR TITLE
fix(ui): refresh expset cache

### DIFF
--- a/evalap/ui/demo_streamlit/views/experiments_set.py
+++ b/evalap/ui/demo_streamlit/views/experiments_set.py
@@ -46,7 +46,6 @@ def _fetch_experimentset(expid, partial_expset, refresh=False):
 
 @st.cache_data(ttl=600, max_entries=3)
 def __fetch_experimentset(expid, partial_expset):
-
     experimentset = partial_expset
     if not experimentset:
         raise ValueError("experimentset not found: %s" % expid)


### PR DESCRIPTION
This should fixed the case of the  "experiment not fount" after a creation front the UI. @AudreyCLEVY  