### PR TITLE
Ensure pray command checks out clean PR branch

### DIFF
--- a/justfile
+++ b/justfile
@@ -361,6 +361,18 @@ pray:
   # Fetch and checkout branch (fresh copy)
   echo "🔄 Fetching and checking out branch: $selected_branch..."
   git fetch origin "$selected_branch"
+
+  echo ""
+  echo "⚠️  WARNING: The following operations will:"
+  echo "   - Remove ALL untracked files and directories (git clean -fd)"
+  echo "   - Discard ALL local uncommitted changes (git reset --hard)"
+  echo ""
+  read -p "   Type 'yes' to continue: " confirm_clean
+  if [ "$confirm_clean" != "yes" ]; then
+    echo "❌ Aborted by user"
+    exit 1
+  fi
+
   git clean -fd  # Remove untracked files and directories
   git reset --hard "origin/$selected_branch"  # Reset to match remote exactly
 


### PR DESCRIPTION
## Summary
- Rename `pra` helper to `pray` for better clarity
- Ensure clean PR checkouts with:
  - `git clean -fd` to remove untracked files
  - `git reset --hard origin/branch` to match remote branch exactly
- Keep virtual environments (`.venv`) and environment files (`.env`) safe (they're in .gitignore)

## Testing
1. Run `just pray` and select a PR
2. Verify:
   - Local changes are discarded
   - Untracked files are removed
   - Working directory matches the PR branch exactly
   - Virtual environment and .env files remain intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive PR selection interface with truncated titles and input validation for easier browsing.
  * Safer branch checkout that fetches remote, prompts before destructive actions, and synchronizes local state to remote.
  * GitHub CLI presence check with early exit notification.
  * Optional PostgreSQL volume cleanup during workflow execution.

* **Chores**
  * Workflow command renamed for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->